### PR TITLE
feat: underline navigation links based on current url

### DIFF
--- a/src/main-header/main-header.utils.jsx
+++ b/src/main-header/main-header.utils.jsx
@@ -1,7 +1,51 @@
 import EoscMainHeaderLogoutBtn from "./main-header-logout-btn.component";
 import EoscMainHeaderLoginBtn from "./main-header-login-btn.component";
 
+const BROWSE_RESOURCES_HOSTS = ["eosc.pl", "marketplace.eosc.pl"];
+
+function parseUrl(url) {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+function isCurrentHost(hosts) {
+  return hosts.includes(window.location.hostname);
+}
+
+function isBrowseResourcesBtn(btnUrl) {
+  const parsedBtnUrl = parseUrl(btnUrl);
+
+  return parsedBtnUrl?.hostname === "eosc.pl" && parsedBtnUrl.pathname.includes("/search");
+}
+
+function isWorkWithDataBtn(btnUrl) {
+  return parseUrl(btnUrl)?.hostname === "data.eosc.pl";
+}
+
+function isOnedataPage() {
+  return `${window.location.href || ""}`.includes("onedata");
+}
+
+function isKnownEoscAppBtnActive(btnUrl) {
+  if (isBrowseResourcesBtn(btnUrl)) {
+    return isCurrentHost(BROWSE_RESOURCES_HOSTS);
+  }
+
+  if (isWorkWithDataBtn(btnUrl)) {
+    return isOnedataPage();
+  }
+
+  return false;
+}
+
 export function isBtnActive(btnsUrls, btnUrl) {
+  if (isKnownEoscAppBtnActive(btnUrl)) {
+    return true;
+  }
+
   const currentUrlBase = `${window.location.protocol}//${window.location.hostname}`;
   if (!btnUrl.includes(currentUrlBase)) {
     return false;

--- a/src/main-header/main-header.utils.spec.js
+++ b/src/main-header/main-header.utils.spec.js
@@ -1,8 +1,9 @@
 import { isBtnActive } from "./main-header.utils";
 
 // Helper method to mock window.location
-const mockLocation = (hostname, protocol, pathname) => {
+const mockLocation = (hostname, protocol, pathname, href = `${protocol}//${hostname}${pathname}`) => {
   const location = {
+    href,
     hostname,
     protocol,
     pathname
@@ -54,5 +55,33 @@ describe("Main header btns underline", () => {
     mockLocation("localhost", "https:", "/contact-us");
     expect(isBtnActive(urls, urls[0])).toBe(false);
     expect(isBtnActive(urls, urls[1])).toBe(true);
+  });
+
+  test("should underline Browse resources on Marketplace and Discovery Hub pages", () => {
+    const urls = [
+      "https://eosc.gov.pl/",
+      "https://eosc.pl/search/all_collection?q=*",
+      "https://data.eosc.pl/"
+    ];
+
+    mockLocation("marketplace.eosc.pl", "https:", "/services");
+    expect(isBtnActive(urls, urls[1])).toBe(true);
+    expect(isBtnActive(urls, urls[2])).toBe(false);
+
+    mockLocation("eosc.pl", "https:", "/providers");
+    expect(isBtnActive(urls, urls[1])).toBe(true);
+    expect(isBtnActive(urls, urls[2])).toBe(false);
+  });
+
+  test("should underline Work with data on Onedata pages", () => {
+    const urls = [
+      "https://eosc.gov.pl/",
+      "https://eosc.pl/search/all_collection?q=*",
+      "https://data.eosc.pl/"
+    ];
+
+    mockLocation("data.eosc.pl", "https:", "/ozw/onezone/i", "https://data.eosc.pl/ozw/onezone/i#/onedata/users");
+    expect(isBtnActive(urls, urls[1])).toBe(false);
+    expect(isBtnActive(urls, urls[2])).toBe(true);
   });
 });


### PR DESCRIPTION
Closes cyfronet-fid/eosc-search-service#1890

Underlines link when at address `marketplace.eosc.pl` or `eosc.pl`
<img width="972" height="146" alt="image" src="https://github.com/user-attachments/assets/f0a2904c-9d44-46e1-b9fb-c754e5f3aa33" />


When at `data.eosc.pl`
<img width="958" height="145" alt="image" src="https://github.com/user-attachments/assets/3d47ab7e-f775-458b-bcde-1f3abd46f3e9" />
