### PR TITLE
style: tabs fix

### DIFF
--- a/styles/main-header.scss
+++ b/styles/main-header.scss
@@ -266,14 +266,19 @@
             margin-bottom: 17px;
 
             .dropdown-tabs {
+              background: #fff !important;
+
+              &.nav-tabs {
+                background: #fff !important;
+                align-items: flex-end;
+              }
 
               a.nav-link {
                 font-weight: 400;
                 text-transform: uppercase;
                 font-size: 15px;
                 color: #363939;
-                padding-bottom: 10px;
-                padding-top: 6px;
+                padding: 6px 9px 10px;
 
                 &:hover {
                   color: shared.$color-primary;
@@ -283,6 +288,7 @@
                 &.active {
                   color: shared.$color-primary;
                   border-bottom: 2px solid shared.$color-primary;
+                  padding-bottom: 7px;
                 }
 
               }

--- a/styles/main-header.scss
+++ b/styles/main-header.scss
@@ -288,7 +288,7 @@
                 &.active {
                   color: shared.$color-primary;
                   border-bottom: 2px solid shared.$color-primary;
-                  padding-bottom: 7px;
+                  padding-bottom: 9px;
                 }
 
               }


### PR DESCRIPTION
fix for overridden CSS styles in tabs

<img width="602" height="764" alt="image" src="https://github.com/user-attachments/assets/39482693-b8aa-4c77-82fa-a9779f985e8c" />
