### PR TITLE
style: [#90] drop-down mods

### DIFF
--- a/src/main-header/main-header.interface.examples.md
+++ b/src/main-header/main-header.interface.examples.md
@@ -226,3 +226,15 @@ Use default eosc links with custom tab definded via `custom-tabs`
     custom-tabs='[{"id":"provider","name":"Provider","links":[{"caption":"Backoffice","href":"https://marketplace.eosc.pl/backoffice/services"},{"caption":"Ordering system","href":"https://bos.eosc.pl/","dividerAfter":true},{"caption":"+ Add new service","href":"https://marketplace.eosc.pl/backoffice/services/new"},{"caption":"+ Add new provider","href":"https://marketplace.eosc.pl/backoffice/providers/new/wizard"},{"caption":"+ Add new catalogue","href":"https://marketplace.eosc.pl/backoffice/catalogues/new","dividerAfter":true},{"caption":"Documentation","href":"#"}]}]'
 ></EoscCommonMainHeader>
 ```
+
+Use default eosc links with custom tab definded via `custom-tabs`
+
+```js
+<EoscCommonMainHeader
+    username="John Doe"
+    on-logout="alert('logout btn');"
+    login-url="https://marketplace.eosc.pl/users/auth/checkin"
+    show-eosc-links="true"
+    custom-tabs='[{"id":"provider","name":"Provider","links":[{"caption":"Become provider","href":"https://marketplace.eosc.pl/backoffice/services","dividerAfter":true},{"caption":"Documentation","href":"#"}]}]'
+></EoscCommonMainHeader>
+```

--- a/styles/main-header.scss
+++ b/styles/main-header.scss
@@ -315,6 +315,11 @@
               background: #FEF2F4;
             }
 
+            &:focus {
+              outline: 1px solid #257B85;
+              background: #fff;
+            }
+
             &.one-data {
               background-image: url(assets/one-data.svg);
               background-repeat: no-repeat;


### PR DESCRIPTION
closes: https://github.com/cyfronet-fid/pl-marketplace/issues/90

Added drop-down menu preview for user/provider profiles:

<img width="500" height="768" alt="Image" src="https://github.com/user-attachments/assets/34e1e9c4-2389-4246-a74b-842ec8a4706a" />

<img width="530" height="540" alt="Image" src="https://github.com/user-attachments/assets/d9f7c1ed-b158-4a35-970a-8f6bb641f2c1" />

In the project we have a defined appearance of the menu, but what links will be included in it probably depends on how the system, which includes the header, will be configured.